### PR TITLE
User not found verify false

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+hard_tabs = true
+edition = "2018"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "htpasswd-verify"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["aQaTL <mmsoltys@outlook.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,13 @@ pub struct MD5Hash<'a> {
 
 impl Htpasswd<'_> {
 	pub fn check(&self, username: &str, password: &str) -> bool {
-		let hash = &self.0[username];
+		let hash = &self.0.get(username);
 		match hash {
-			Hash::MD5(hash) => md5::md5_apr1_encode(password, hash.salt).as_str() == hash.hash,
-			Hash::BCrypt(hash) => bcrypt::verify(password, hash).unwrap(),
-			Hash::SHA1(hash) => {
+			Some(Hash::MD5(hash)) => {
+				md5::md5_apr1_encode(password, hash.salt).as_str() == hash.hash
+			}
+			Some(Hash::BCrypt(hash)) => bcrypt::verify(password, hash).unwrap(),
+			Some(Hash::SHA1(hash)) => {
 				let mut hasher = Sha1::new();
 				hasher.input_str(password);
 				let size = hasher.output_bytes();
@@ -63,7 +65,8 @@ impl Htpasswd<'_> {
 				hasher.result(&mut buf);
 				base64::encode(&buf).as_str() == *hash
 			}
-			Hash::Crypt(hash) => pwhash::unix_crypt::verify(password, hash),
+			Some(Hash::Crypt(hash)) => pwhash::unix_crypt::verify(password, hash),
+			None => false,
 		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,4 +163,10 @@ crypt_test:bGVh02xkuGli2";
 			md5::verify_apr1_hash("$apr1$xxxxxxxx$dxHfLAsjHkDRmG83UXe8K0", "password").unwrap()
 		);
 	}
+
+	#[test]
+	fn user_not_found() {
+		let htpasswd = load(DATA);
+		assert_eq!(htpasswd.check("user_does_not_exist", "password"), false);
+	}
 }


### PR DESCRIPTION
instead of panic, check() now returns false when a user is not found in the htpasswd data.

Makes this library useful when used for e.g. a "http basic auth" filter on a warp based web server, here you want to return an unauthorised header instead of connection closed (the latter is caused by the panic).