### PR TITLE
bcrypt=0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ members = [ "bin" ]
 
 [dependencies]
 base64 = "0.11"
-bcrypt = "0.6"
+bcrypt = "0.10.1"
 rust-crypto = "0.2"
 pwhash = "0.3"


### PR DESCRIPTION
Good day,

please update bcrypt dep. to the latest cuz v0.6-dependent block-cipher-trait crate is now deprecated.